### PR TITLE
Add review slider defaults to settings

### DIFF
--- a/sdc-gmb-review-badge.php
+++ b/sdc-gmb-review-badge.php
@@ -35,6 +35,12 @@ function sdc_gmb_get_default_options() {
         'star_color'    => '#E9966F',
         'accent_color'  => '#1E2A3A',
         'cache_minutes' => 720,
+        'min_rating'    => 0.0,
+        'reviews_limit' => 6,
+        'slides_desktop' => 3,
+        'slides_tablet'  => 2,
+        'slides_mobile'  => 1,
+        'elementor_skin' => 'badge', // TODO: Confirm Elementor skin slug expectation once widget integration is finalised.
     );
 }
 
@@ -129,6 +135,72 @@ function sdc_gmb_register_settings() {
         'sdc_gmb_review_badge',
         'sdc_gmb_review_badge_section'
     );
+
+    add_settings_field(
+        'min_rating',
+        __( 'Minimum Review Rating', 'sdc-gmb-review-badge' ),
+        'sdc_gmb_render_min_rating_field',
+        'sdc_gmb_review_badge',
+        'sdc_gmb_review_badge_section'
+    );
+
+    add_settings_field(
+        'reviews_limit',
+        __( 'Reviews Limit', 'sdc-gmb-review-badge' ),
+        'sdc_gmb_render_reviews_limit_field',
+        'sdc_gmb_review_badge',
+        'sdc_gmb_review_badge_section'
+    );
+
+    add_settings_field(
+        'slides_desktop',
+        __( 'Desktop Slides Visible', 'sdc-gmb-review-badge' ),
+        'sdc_gmb_render_slide_count_field',
+        'sdc_gmb_review_badge',
+        'sdc_gmb_review_badge_section',
+        array(
+            'key'         => 'slides_desktop',
+            'input_id'    => 'sdc-gmb-slides-desktop',
+            'max'         => 5,
+            'description' => __( 'Number of review cards to display side-by-side on desktop breakpoints.', 'sdc-gmb-review-badge' ),
+        )
+    );
+
+    add_settings_field(
+        'slides_tablet',
+        __( 'Tablet Slides Visible', 'sdc-gmb-review-badge' ),
+        'sdc_gmb_render_slide_count_field',
+        'sdc_gmb_review_badge',
+        'sdc_gmb_review_badge_section',
+        array(
+            'key'         => 'slides_tablet',
+            'input_id'    => 'sdc-gmb-slides-tablet',
+            'max'         => 4,
+            'description' => __( 'Number of review cards to display on medium-width tablet layouts.', 'sdc-gmb-review-badge' ),
+        )
+    );
+
+    add_settings_field(
+        'slides_mobile',
+        __( 'Mobile Slides Visible', 'sdc-gmb-review-badge' ),
+        'sdc_gmb_render_slide_count_field',
+        'sdc_gmb_review_badge',
+        'sdc_gmb_review_badge_section',
+        array(
+            'key'         => 'slides_mobile',
+            'input_id'    => 'sdc-gmb-slides-mobile',
+            'max'         => 3,
+            'description' => __( 'Number of review cards to display on small-screen devices.', 'sdc-gmb-review-badge' ),
+        )
+    );
+
+    add_settings_field(
+        'elementor_skin',
+        __( 'Elementor Skin', 'sdc-gmb-review-badge' ),
+        'sdc_gmb_render_elementor_skin_field',
+        'sdc_gmb_review_badge',
+        'sdc_gmb_review_badge_section'
+    );
 }
 add_action( 'admin_init', 'sdc_gmb_register_settings' );
 
@@ -140,6 +212,7 @@ add_action( 'admin_init', 'sdc_gmb_register_settings' );
  */
 function sdc_gmb_sanitize_options( $input ) {
     $options   = sdc_gmb_get_options();
+    $defaults  = sdc_gmb_get_default_options();
     $sanitized = array();
 
     $sanitized['api_key']       = isset( $input['api_key'] ) ? sanitize_text_field( $input['api_key'] ) : $options['api_key'];
@@ -148,6 +221,20 @@ function sdc_gmb_sanitize_options( $input ) {
     $sanitized['star_color']    = isset( $input['star_color'] ) ? sanitize_hex_color( $input['star_color'] ) : $options['star_color'];
     $sanitized['accent_color']  = isset( $input['accent_color'] ) ? sanitize_hex_color( $input['accent_color'] ) : $options['accent_color'];
     $sanitized['cache_minutes'] = isset( $input['cache_minutes'] ) ? absint( $input['cache_minutes'] ) : $options['cache_minutes'];
+    $sanitized['min_rating']    = isset( $input['min_rating'] ) ? floatval( $input['min_rating'] ) : (float) $options['min_rating'];
+    $sanitized['reviews_limit'] = isset( $input['reviews_limit'] ) ? absint( $input['reviews_limit'] ) : absint( $options['reviews_limit'] );
+
+    $slide_keys = array(
+        'slides_desktop',
+        'slides_tablet',
+        'slides_mobile',
+    );
+
+    foreach ( $slide_keys as $slide_key ) {
+        $sanitized[ $slide_key ] = isset( $input[ $slide_key ] ) ? absint( $input[ $slide_key ] ) : absint( $options[ $slide_key ] );
+    }
+
+    $sanitized['elementor_skin'] = isset( $input['elementor_skin'] ) ? sanitize_key( $input['elementor_skin'] ) : sanitize_key( $options['elementor_skin'] );
 
     if ( $sanitized['stars'] < 1 ) {
         $sanitized['stars'] = 1;
@@ -156,11 +243,42 @@ function sdc_gmb_sanitize_options( $input ) {
     }
 
     if ( empty( $sanitized['star_color'] ) ) {
-        $sanitized['star_color'] = sdc_gmb_get_default_options()['star_color'];
+        $sanitized['star_color'] = $defaults['star_color'];
     }
 
     if ( empty( $sanitized['accent_color'] ) ) {
-        $sanitized['accent_color'] = sdc_gmb_get_default_options()['accent_color'];
+        $sanitized['accent_color'] = $defaults['accent_color'];
+    }
+
+    if ( $sanitized['min_rating'] < 0 ) {
+        $sanitized['min_rating'] = 0.0;
+    } elseif ( $sanitized['min_rating'] > 5 ) {
+        $sanitized['min_rating'] = 5.0;
+    }
+
+    if ( $sanitized['reviews_limit'] < 1 ) {
+        $sanitized['reviews_limit'] = $defaults['reviews_limit'];
+    } elseif ( $sanitized['reviews_limit'] > 10 ) {
+        // TODO: Confirm maximum reviews supported without pagination once API usage requirements are confirmed.
+        $sanitized['reviews_limit'] = 10;
+    }
+
+    $slide_caps = array(
+        'slides_desktop' => 5,
+        'slides_tablet'  => 4,
+        'slides_mobile'  => 3,
+    );
+
+    foreach ( $slide_caps as $slide_key => $max ) {
+        if ( $sanitized[ $slide_key ] < 1 ) {
+            $sanitized[ $slide_key ] = $defaults[ $slide_key ];
+        } elseif ( $sanitized[ $slide_key ] > $max ) {
+            $sanitized[ $slide_key ] = $max;
+        }
+    }
+
+    if ( empty( $sanitized['elementor_skin'] ) ) {
+        $sanitized['elementor_skin'] = sanitize_key( $defaults['elementor_skin'] );
     }
 
     return $sanitized;
@@ -260,6 +378,87 @@ function sdc_gmb_render_cache_field() {
     );
 
     echo '<p class="description">' . esc_html__( 'Cache the Google API response for this many minutes. Set to 0 to disable caching temporarily.', 'sdc-gmb-review-badge' ) . '</p>';
+}
+
+/**
+ * Render minimum rating field.
+ */
+function sdc_gmb_render_min_rating_field() {
+    $options     = sdc_gmb_get_options();
+    $min_rating  = isset( $options['min_rating'] ) ? (float) $options['min_rating'] : sdc_gmb_get_default_options()['min_rating'];
+    $input_value = number_format( $min_rating, 1, '.', '' );
+
+    printf(
+        '<input type="number" min="0" max="5" step="0.1" name="sdc_gmb_review_badge_options[min_rating]" id="sdc-gmb-min-rating" value="%s" />',
+        esc_attr( $input_value )
+    );
+
+    echo '<p class="description">' . esc_html__( 'Ignore reviews below this rating when rendering Elementor carousels or lists.', 'sdc-gmb-review-badge' ) . '</p>';
+}
+
+/**
+ * Render reviews limit field.
+ */
+function sdc_gmb_render_reviews_limit_field() {
+    $options = sdc_gmb_get_options();
+
+    printf(
+        '<input type="number" min="1" max="10" name="sdc_gmb_review_badge_options[reviews_limit]" id="sdc-gmb-reviews-limit" value="%d" />',
+        absint( $options['reviews_limit'] )
+    );
+
+    echo '<p class="description">' . esc_html__( 'Cap how many Google reviews to fetch for Elementor-powered layouts.', 'sdc-gmb-review-badge' ) . '</p>';
+}
+
+/**
+ * Render slide count field for responsive breakpoints.
+ *
+ * @param array $args Callback arguments.
+ */
+function sdc_gmb_render_slide_count_field( $args ) {
+    $defaults = array(
+        'key'         => '',
+        'input_id'    => '',
+        'max'         => 3,
+        'description' => '',
+    );
+
+    $args    = wp_parse_args( $args, $defaults );
+    $options = sdc_gmb_get_options();
+    $key     = $args['key'];
+
+    if ( '' === $key ) {
+        return;
+    }
+
+    $value = isset( $options[ $key ] ) ? absint( $options[ $key ] ) : absint( sdc_gmb_get_default_options()[ $key ] );
+
+    printf(
+        '<input type="number" min="1" max="%1$d" name="sdc_gmb_review_badge_options[%2$s]" id="%3$s" value="%4$d" />',
+        absint( $args['max'] ),
+        esc_attr( $key ),
+        esc_attr( $args['input_id'] ),
+        $value
+    );
+
+    if ( ! empty( $args['description'] ) ) {
+        echo '<p class="description">' . esc_html( $args['description'] ) . '</p>';
+    }
+}
+
+/**
+ * Render Elementor skin field.
+ */
+function sdc_gmb_render_elementor_skin_field() {
+    $options = sdc_gmb_get_options();
+    $skin    = isset( $options['elementor_skin'] ) ? sanitize_key( $options['elementor_skin'] ) : sanitize_key( sdc_gmb_get_default_options()['elementor_skin'] );
+
+    printf(
+        '<input type="text" name="sdc_gmb_review_badge_options[elementor_skin]" id="sdc-gmb-elementor-skin" value="%s" class="regular-text" />',
+        esc_attr( $skin )
+    );
+
+    echo '<p class="description">' . esc_html__( 'Default Elementor skin slug for the reviews widget. Adjust only if you have custom Elementor templates.', 'sdc-gmb-review-badge' ) . '</p>';
 }
 
 /**


### PR DESCRIPTION
## Summary
- extend plugin defaults with review slider and Elementor configuration values
- validate and sanitize new controls, enforcing sensible fallbacks
- register and render settings fields for minimum rating, review limits, device-specific slide counts, and Elementor skin slug

## Testing
- php -l sdc-gmb-review-badge.php

------
https://chatgpt.com/codex/tasks/task_b_68fadad43a74832caac527a921e7a044