### PR TITLE
Add accessible Google reviews carousel shortcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.0] - 2025-10-24
+### Added
+- Reviews carousel shortcode with rating filters, accessible controls, and Elementor guidance.
+- Front-end carousel assets that respect `prefers-reduced-motion` and expose responsive slide counts.
+
+### Changed
+- Documented Elementor usage and shortcode attributes for the new carousel experience.
+
 ## [1.1.0] - 2025-09-17
 ### Added
 - Comprehensive README covering installation, configuration, shortcode options, and caching guidance.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ SDC GMB Review Badge is a lightweight WordPress plugin from [Stoke Design Co](ht
 - Cache API responses to stay within quota limits while keeping data fresh.
 - Customise the number of stars, the star fill colour, and the text/icon accent colour.
 - Accessible, responsive SVG badge markup that works in any theme.
+- Optional reviews carousel with keyboard-friendly controls and reduced-motion support.
 - Shortcode aliases for backward compatibility with previous plugin versions.
 
 ## Requirements
@@ -65,6 +66,40 @@ Add the badge anywhere shortcodes are supported (pages, posts, widgets, block ed
 ```
 
 For convenience, the plugin still recognises the legacy shortcodes `[sdc_gmb_badge]` and `[stoke_gbp_badge]`, both of which resolve to the same output.
+
+### Reviews carousel shortcode
+
+Display a responsive slider of recent Google reviews with:
+
+```text
+[sdc_gmb_reviews_carousel]
+```
+
+| Attribute         | Description                                                                                 | Default (from settings) |
+|-------------------|---------------------------------------------------------------------------------------------|-------------------------|
+| `place_id`        | Override the configured Place ID.                                                           | Saved Place ID          |
+| `api_key`         | Override the configured API key.                                                            | Saved API key           |
+| `cache_minutes`   | Minutes to cache the Places API response.                                                   | Saved cache duration    |
+| `min_rating`      | Filter out reviews below this rating (0–5, decimal friendly).                               | Saved minimum rating    |
+| `reviews_limit`   | Maximum number of reviews to render (1–8; Google returns up to 8 recent reviews).           | Saved reviews limit     |
+| `slides_desktop`  | Number of cards visible on desktop breakpoints (~960px and up).                              | Saved desktop slides    |
+| `slides_tablet`   | Number of cards visible on tablet breakpoints (~600px and up).                               | Saved tablet slides     |
+| `slides_mobile`   | Number of cards visible below 600px.                                                         | Saved mobile slides     |
+
+The shortcode outputs semantic markup that includes:
+
+- `role="region"` and a polite live region announcing the visible range for assistive tech.
+- Previous/next buttons with disabled states, smooth scrolling, and reduced-motion fallbacks.
+- CSS custom properties and data attributes (`data-slides-desktop`, etc.) reflecting the per-breakpoint slide counts for further styling hooks.
+
+If no reviews meet the filter criteria, a translated fallback message is displayed instead of the carousel.
+
+### Elementor integration
+
+1. Add the **Shortcode** widget to your Elementor layout.
+2. Paste either `[sdc_gmb_review_badge]` or `[sdc_gmb_reviews_carousel]` into the widget content.
+3. Adjust the widget width/padding as needed—responsive sizing is controlled via the shortcode attributes and plugin settings.
+4. Publish or update the page and clear any caches so the Places API data can refresh.
 
 ## Styling tips
 

--- a/assets/css/review-carousel.css
+++ b/assets/css/review-carousel.css
@@ -1,0 +1,151 @@
+.sdc-gmb-carousel {
+    --sdc-gmb-gap: 1.25rem;
+    --sdc-gmb-slides-desktop: 3;
+    --sdc-gmb-slides-tablet: 2;
+    --sdc-gmb-slides-mobile: 1;
+    --sdc-gmb-current-slides: var(--sdc-gmb-slides-mobile);
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.sdc-gmb-carousel__controls {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+}
+
+.sdc-gmb-carousel__button {
+    border: 1px solid #1e2a3a;
+    background: #1e2a3a;
+    color: #fff;
+    padding: 0.5rem 0.875rem;
+    font-size: 0.875rem;
+    font-weight: 600;
+    border-radius: 999px;
+    cursor: pointer;
+    transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.sdc-gmb-carousel__button:focus,
+.sdc-gmb-carousel__button:hover {
+    background: transparent;
+    color: #1e2a3a;
+}
+
+.sdc-gmb-carousel__button:focus-visible {
+    outline: 2px solid #1e2a3a;
+    outline-offset: 2px;
+}
+
+.sdc-gmb-carousel__viewport {
+    overflow: hidden;
+}
+
+.sdc-gmb-carousel__list {
+    display: flex;
+    gap: var(--sdc-gmb-gap);
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+    scroll-padding: 1rem;
+}
+
+.sdc-gmb-carousel__item {
+    flex: 0 0 calc((100% - (var(--sdc-gmb-current-slides) - 1) * var(--sdc-gmb-gap)) / var(--sdc-gmb-current-slides));
+    scroll-snap-align: start;
+}
+
+.sdc-gmb-review-card {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    padding: 1.25rem;
+    border-radius: 1rem;
+    background: #f4f6f9;
+    color: #1e2a3a;
+    box-shadow: 0 10px 30px rgba(17, 24, 39, 0.1);
+}
+
+.sdc-gmb-review-card__header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.sdc-gmb-review-card__rating {
+    display: inline-flex;
+    gap: 0.25rem;
+}
+
+.sdc-gmb-review-card__meta {
+    font-size: 0.875rem;
+    color: #4d5d72;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    align-items: center;
+}
+
+.sdc-gmb-review-card__text {
+    margin: 0;
+    font-size: 1rem;
+    line-height: 1.5;
+    color: inherit;
+}
+
+.sdc-gmb-review-card__separator {
+    opacity: 0.6;
+}
+
+.sdc-gmb-carousel__status {
+    margin: 0;
+}
+
+.sdc-gmb-carousel--empty,
+.sdc-gmb-carousel--error {
+    background: #f4f6f9;
+    border-radius: 1rem;
+    padding: 1.5rem;
+    color: #1e2a3a;
+}
+
+.sdc-gmb-carousel--empty p,
+.sdc-gmb-carousel--error p {
+    margin: 0;
+}
+
+.screen-reader-text {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    border: 0;
+}
+
+@media (min-width: 600px) {
+    .sdc-gmb-carousel {
+        --sdc-gmb-current-slides: var(--sdc-gmb-slides-tablet);
+    }
+}
+
+@media (min-width: 960px) {
+    .sdc-gmb-carousel {
+        --sdc-gmb-current-slides: var(--sdc-gmb-slides-desktop);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .sdc-gmb-carousel__button {
+        transition: none;
+    }
+
+    .sdc-gmb-carousel__list {
+        scroll-behavior: auto;
+    }
+}

--- a/assets/js/review-carousel.js
+++ b/assets/js/review-carousel.js
@@ -1,0 +1,140 @@
+(function () {
+    'use strict';
+
+    var prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+    var numberFormatter = new Intl.NumberFormat(window.document.documentElement.lang || undefined);
+
+    function getSlidesPerView(carousel) {
+        var desktop = parseInt(carousel.getAttribute('data-slides-desktop'), 10) || 1;
+        var tablet = parseInt(carousel.getAttribute('data-slides-tablet'), 10) || 1;
+        var mobile = parseInt(carousel.getAttribute('data-slides-mobile'), 10) || 1;
+        var width = window.innerWidth || document.documentElement.clientWidth;
+
+        if (width >= 960) {
+            return desktop;
+        }
+
+        if (width >= 600) {
+            return tablet;
+        }
+
+        return mobile;
+    }
+
+    function formatStatus(start, end, total) {
+        var template = (window.sdcGmbCarouselL10n && window.sdcGmbCarouselL10n.status) || 'Showing reviews %1$s–%2$s of %3$s';
+
+        return template
+            .replace('%1$s', numberFormatter.format(start))
+            .replace('%2$s', numberFormatter.format(end))
+            .replace('%3$s', numberFormatter.format(total));
+    }
+
+    function updateNavState(list, prevButton, nextButton) {
+        var maxScroll = list.scrollWidth - list.clientWidth;
+
+        if (prevButton) {
+            prevButton.disabled = list.scrollLeft <= 1;
+        }
+
+        if (nextButton) {
+            nextButton.disabled = list.scrollLeft + 1 >= maxScroll;
+        }
+    }
+
+    function updateStatus(carousel, list, items, liveRegion) {
+        if (!liveRegion) {
+            return;
+        }
+
+        var slides = getSlidesPerView(carousel);
+        var total = items.length;
+        var itemWidth = total ? list.scrollWidth / total : 0;
+        var index = itemWidth ? Math.round(list.scrollLeft / itemWidth) : 0;
+        var start = Math.min(index + 1, total);
+        var end = Math.min(index + slides, total);
+
+        if (start < 1) {
+            start = 1;
+        }
+
+        liveRegion.textContent = formatStatus(start, end, total);
+    }
+
+    function scrollBySlides(list, carousel, direction) {
+        var items = list.querySelectorAll('[data-carousel-item]');
+        var total = items.length;
+
+        if (!total) {
+            return;
+        }
+
+        var slides = getSlidesPerView(carousel);
+        var itemWidth = list.scrollWidth / total;
+        var scrollAmount = itemWidth * slides * direction;
+        var behavior = prefersReducedMotion.matches ? 'auto' : 'smooth';
+
+        list.scrollBy({ left: scrollAmount, behavior: behavior });
+    }
+
+    function initCarousel(carousel) {
+        var list = carousel.querySelector('[data-carousel-list]');
+        var items = list ? list.querySelectorAll('[data-carousel-item]') : [];
+
+        if (!list || !items.length) {
+            return;
+        }
+
+        var prevButton = carousel.querySelector('[data-carousel-prev]');
+        var nextButton = carousel.querySelector('[data-carousel-next]');
+        var liveRegion = carousel.querySelector('[data-carousel-live]');
+        var rafId;
+
+        function handleScroll() {
+            if (rafId) {
+                window.cancelAnimationFrame(rafId);
+            }
+
+            rafId = window.requestAnimationFrame(function () {
+                updateStatus(carousel, list, items, liveRegion);
+                updateNavState(list, prevButton, nextButton);
+            });
+        }
+
+        if (prevButton) {
+            prevButton.addEventListener('click', function () {
+                scrollBySlides(list, carousel, -1);
+            });
+        }
+
+        if (nextButton) {
+            nextButton.addEventListener('click', function () {
+                scrollBySlides(list, carousel, 1);
+            });
+        }
+
+        list.addEventListener('scroll', handleScroll, { passive: true });
+
+        window.addEventListener('resize', handleScroll);
+
+        if (prefersReducedMotion.addEventListener) {
+            prefersReducedMotion.addEventListener('change', handleScroll);
+        }
+
+        handleScroll();
+    }
+
+    function init() {
+        var carousels = document.querySelectorAll('.sdc-gmb-carousel[data-carousel-total]');
+
+        carousels.forEach(function (carousel) {
+            initCarousel(carousel);
+        });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();

--- a/sdc-gmb-review-badge.php
+++ b/sdc-gmb-review-badge.php
@@ -3,7 +3,7 @@
  * Plugin Name: SDC GMB Review Badge
  * Plugin URI: https://stokedesign.co
  * Description: Display a Google Business Profile rating badge anywhere on your site via shortcode with configurable styling, caching, and accessible markup.
- * Version: 1.1.0
+ * Version: 1.2.0
  * Author: Stoke Design Co
  * Author URI: https://stokedesign.co
  * Text Domain: sdc-gmb-review-badge
@@ -12,6 +12,10 @@
 
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
+}
+
+if ( ! defined( 'SDC_GMB_REVIEW_BADGE_VERSION' ) ) {
+    define( 'SDC_GMB_REVIEW_BADGE_VERSION', '1.2.0' );
 }
 
 /**
@@ -665,7 +669,7 @@ function sdc_gmb_enqueue_badge_style() {
     $handle             = 'sdc-gmb-review-badge';
 
     if ( ! wp_style_is( $handle, 'registered' ) ) {
-        wp_register_style( $handle, false, array(), '1.1.0' );
+        wp_register_style( $handle, false, array(), SDC_GMB_REVIEW_BADGE_VERSION );
     }
 
     if ( ! wp_style_is( $handle, 'enqueued' ) ) {
@@ -687,6 +691,233 @@ function sdc_gmb_enqueue_badge_style() {
         wp_add_inline_style( $handle, $css );
         $style_added = true;
     }
+}
+
+/**
+ * Register front-end assets for the reviews carousel.
+ */
+function sdc_gmb_register_reviews_carousel_assets() {
+    $style_handle  = 'sdc-gmb-reviews-carousel';
+    $script_handle = 'sdc-gmb-reviews-carousel';
+
+    if ( ! wp_style_is( $style_handle, 'registered' ) ) {
+        wp_register_style(
+            $style_handle,
+            plugins_url( 'assets/css/review-carousel.css', __FILE__ ),
+            array(),
+            SDC_GMB_REVIEW_BADGE_VERSION
+        );
+    }
+
+    if ( ! wp_script_is( $script_handle, 'registered' ) ) {
+        wp_register_script(
+            $script_handle,
+            plugins_url( 'assets/js/review-carousel.js', __FILE__ ),
+            array(),
+            SDC_GMB_REVIEW_BADGE_VERSION,
+            true
+        );
+
+        wp_script_add_data( $script_handle, 'strategy', 'defer' );
+
+        wp_localize_script(
+            $script_handle,
+            'sdcGmbCarouselL10n',
+            array(
+                'status' => __( 'Showing reviews %1$s–%2$s of %3$s', 'sdc-gmb-review-badge' ),
+            )
+        );
+    }
+}
+add_action( 'wp_enqueue_scripts', 'sdc_gmb_register_reviews_carousel_assets' );
+
+/**
+ * Render the reviews carousel shortcode.
+ *
+ * @param array $atts Shortcode attributes.
+ * @return string
+ */
+function sdc_gmb_render_reviews_carousel_shortcode( $atts ) {
+    $options = sdc_gmb_get_options();
+
+    $atts = shortcode_atts(
+        array(
+            'place_id'      => $options['place_id'],
+            'api_key'       => $options['api_key'],
+            'cache_minutes' => $options['cache_minutes'],
+            'min_rating'    => $options['min_rating'],
+            'reviews_limit' => $options['reviews_limit'],
+            'slides_desktop'=> $options['slides_desktop'],
+            'slides_tablet' => $options['slides_tablet'],
+            'slides_mobile' => $options['slides_mobile'],
+        ),
+        $atts,
+        'sdc_gmb_reviews_carousel'
+    );
+
+    $place_id      = sanitize_text_field( $atts['place_id'] );
+    $api_key       = sanitize_text_field( $atts['api_key'] );
+    $cache_minutes = absint( $atts['cache_minutes'] );
+    $min_rating    = (float) $atts['min_rating'];
+    $reviews_limit = absint( $atts['reviews_limit'] );
+    $slides_desktop = max( 1, absint( $atts['slides_desktop'] ) );
+    $slides_tablet  = max( 1, absint( $atts['slides_tablet'] ) );
+    $slides_mobile  = max( 1, absint( $atts['slides_mobile'] ) );
+
+    if ( $min_rating < 0 ) {
+        $min_rating = 0;
+    } elseif ( $min_rating > 5 ) {
+        $min_rating = 5;
+    }
+
+    if ( $reviews_limit < 1 ) {
+        $reviews_limit = 1;
+    } elseif ( $reviews_limit > 8 ) {
+        $reviews_limit = 8;
+    }
+
+    wp_enqueue_style( 'sdc-gmb-reviews-carousel' );
+
+    $data = sdc_gmb_get_place_details( $place_id, $api_key, $cache_minutes );
+
+    if ( is_wp_error( $data ) ) {
+        return '<div class="sdc-gmb-carousel sdc-gmb-carousel--error"><p>' . esc_html__( 'Reviews unavailable.', 'sdc-gmb-review-badge' ) . '</p></div>';
+    }
+
+    $star_color = sanitize_hex_color( $options['star_color'] );
+
+    if ( empty( $star_color ) ) {
+        $star_color = sdc_gmb_get_default_options()['star_color'];
+    }
+
+    $reviews = array();
+
+    if ( ! empty( $data['reviews'] ) && is_array( $data['reviews'] ) ) {
+        foreach ( $data['reviews'] as $review ) {
+            if ( ! is_array( $review ) ) {
+                continue;
+            }
+
+            $rating = isset( $review['rating'] ) ? (float) $review['rating'] : 0.0;
+
+            if ( $rating < $min_rating ) {
+                continue;
+            }
+
+            $reviews[] = $review;
+
+            if ( count( $reviews ) >= $reviews_limit ) {
+                break;
+            }
+        }
+    }
+
+    if ( empty( $reviews ) ) {
+        return '<div class="sdc-gmb-carousel sdc-gmb-carousel--empty"><p>' . esc_html__( 'No reviews match the current filters yet. Check back soon!', 'sdc-gmb-review-badge' ) . '</p></div>';
+    }
+
+    wp_enqueue_script( 'sdc-gmb-reviews-carousel' );
+
+    $carousel_id = 'sdc-gmb-carousel-' . wp_unique_id();
+    $list_id     = $carousel_id . '-list';
+    $status_id   = $carousel_id . '-status';
+    $total_items = count( $reviews );
+
+    $classes = array(
+        'sdc-gmb-carousel',
+        'sdc-gmb-carousel--desktop-' . $slides_desktop,
+        'sdc-gmb-carousel--tablet-' . $slides_tablet,
+        'sdc-gmb-carousel--mobile-' . $slides_mobile,
+    );
+
+    $style_attribute = sprintf(
+        ' style="--sdc-gmb-slides-desktop:%1$d;--sdc-gmb-slides-tablet:%2$d;--sdc-gmb-slides-mobile:%3$d;"',
+        $slides_desktop,
+        $slides_tablet,
+        $slides_mobile
+    );
+
+    $items_markup = '';
+
+    foreach ( $reviews as $index => $review ) {
+        $author    = isset( $review['author_name'] ) ? sanitize_text_field( $review['author_name'] ) : '';
+        $rating    = isset( $review['rating'] ) ? (float) $review['rating'] : 0.0;
+        $text      = isset( $review['text'] ) ? sanitize_textarea_field( $review['text'] ) : '';
+        $timestamp = isset( $review['time'] ) ? absint( $review['time'] ) : 0;
+
+        $item_label = sprintf(
+            /* translators: 1: review position, 2: total reviews */
+            __( 'Review %1$s of %2$s', 'sdc-gmb-review-badge' ),
+            number_format_i18n( $index + 1 ),
+            number_format_i18n( $total_items )
+        );
+
+        $rating_label = sprintf(
+            /* translators: %s: star rating value */
+            __( 'Rated %s out of 5', 'sdc-gmb-review-badge' ),
+            number_format_i18n( round( $rating, 1 ), 1 )
+        );
+
+        $date_markup = '';
+
+        if ( $timestamp > 0 ) {
+            $date_markup = '<time class="sdc-gmb-review-card__date" datetime="' . esc_attr( gmdate( 'c', $timestamp ) ) . '">' . esc_html( date_i18n( get_option( 'date_format' ), $timestamp ) ) . '</time>';
+        }
+
+        $items_markup .= '<li class="sdc-gmb-carousel__item" data-carousel-item role="group" aria-label="' . esc_attr( $item_label ) . '">';
+        $items_markup .= '<article class="sdc-gmb-review-card">';
+        $items_markup .= '<header class="sdc-gmb-review-card__header">';
+        $items_markup .= '<div class="sdc-gmb-review-card__rating" aria-label="' . esc_attr( $rating_label ) . '" role="img">' . sdc_gmb_get_stars_markup( $rating, 5, $star_color ) . '</div>';
+
+        if ( '' !== $author || '' !== $date_markup ) {
+            $items_markup .= '<p class="sdc-gmb-review-card__meta">';
+
+            if ( '' !== $author ) {
+                $items_markup .= '<span class="sdc-gmb-review-card__author">' . esc_html( $author ) . '</span>';
+            }
+
+            if ( '' !== $author && '' !== $date_markup ) {
+                $items_markup .= '<span class="sdc-gmb-review-card__separator" aria-hidden="true">&bull;</span>';
+            }
+
+            if ( '' !== $date_markup ) {
+                $items_markup .= $date_markup;
+            }
+
+            $items_markup .= '</p>';
+        }
+
+        if ( '' !== $text ) {
+            $items_markup .= '<p class="sdc-gmb-review-card__text">' . esc_html( $text ) . '</p>';
+        }
+
+        $items_markup .= '</header>';
+        $items_markup .= '</article>';
+        $items_markup .= '</li>';
+    }
+
+    $region_label = __( 'Google reviews carousel', 'sdc-gmb-review-badge' );
+
+    $markup  = '<section class="' . esc_attr( implode( ' ', $classes ) ) . '" role="region" aria-label="' . esc_attr( $region_label ) . '" data-slides-desktop="' . esc_attr( $slides_desktop ) . '" data-slides-tablet="' . esc_attr( $slides_tablet ) . '" data-slides-mobile="' . esc_attr( $slides_mobile ) . '" data-carousel-total="' . esc_attr( $total_items ) . '"' . $style_attribute . '>';
+    $markup .= '<div class="sdc-gmb-carousel__controls">';
+    $markup .= '<button type="button" class="sdc-gmb-carousel__button sdc-gmb-carousel__button--prev" data-carousel-prev aria-controls="' . esc_attr( $list_id ) . '">' . esc_html__( 'Previous reviews', 'sdc-gmb-review-badge' ) . '</button>';
+    $markup .= '<button type="button" class="sdc-gmb-carousel__button sdc-gmb-carousel__button--next" data-carousel-next aria-controls="' . esc_attr( $list_id ) . '">' . esc_html__( 'Next reviews', 'sdc-gmb-review-badge' ) . '</button>';
+    $markup .= '</div>';
+    $markup .= '<div class="sdc-gmb-carousel__viewport">';
+    $markup .= '<ul class="sdc-gmb-carousel__list" id="' . esc_attr( $list_id ) . '" data-carousel-list>' . $items_markup . '</ul>';
+    $markup .= '</div>';
+    $markup .= '<p id="' . esc_attr( $status_id ) . '" class="sdc-gmb-carousel__status screen-reader-text" aria-live="polite" data-carousel-live>';
+    $markup .= sprintf(
+        /* translators: 1: starting review index, 2: ending review index, 3: total reviews */
+        esc_html__( 'Showing reviews %1$s–%2$s of %3$s', 'sdc-gmb-review-badge' ),
+        1,
+        min( $slides_mobile, $total_items ),
+        $total_items
+    );
+    $markup .= '</p>';
+    $markup .= '</section>';
+
+    return $markup;
 }
 
 /**
@@ -831,6 +1062,7 @@ function sdc_gmb_render_badge_shortcode( $atts ) {
 
     return $badge;
 }
+add_shortcode( 'sdc_gmb_reviews_carousel', 'sdc_gmb_render_reviews_carousel_shortcode' );
 add_shortcode( 'sdc_gmb_review_badge', 'sdc_gmb_render_badge_shortcode' );
 add_shortcode( 'sdc_gmb_badge', 'sdc_gmb_render_badge_shortcode' );
 add_shortcode( 'stoke_gbp_badge', 'sdc_gmb_render_badge_shortcode' );


### PR DESCRIPTION
## Summary
- add a Google reviews carousel shortcode with rating filters, responsive slide counts, and accessible markup
- register lightweight carousel CSS/JS assets that honor prefers-reduced-motion and only load when the shortcode renders
- document Elementor shortcode usage and update the changelog for version 1.2.0

## Testing
- php -l sdc-gmb-review-badge.php

------
https://chatgpt.com/codex/tasks/task_b_68fadd21ed08832c87abdf9c993822e1