### PR TITLE
Switch carousel CSS to ticker-friendly track

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ SDC Review Carousel is a lightweight WordPress plugin from [Stoke Design Co](htt
 - Pull your live Google rating, total review count, and recent reviews via the Places API.
 - Cache API responses to respect quota limits while keeping data fresh.
 - Customise star counts, badge/review colours (background, text, meta, dots), horizontal spacing, minimum review rating, slide counts, autoplay delay, and transition speed from the settings page.
-- Responsive carousel with dot navigation that appears on hover/focus, keyboard support, and reduced-motion fallbacks.
+- Responsive carousel with dot navigation that appears on hover/focus, keyboard support, a continuous ticker track, and reduced-motion fallbacks.
 - Backwards-compatible shortcode aliases for legacy integrations.
 
 ## Requirements
@@ -108,6 +108,7 @@ Legacy alias `[sdc_gmb_reviews_carousel]` still maps to the updated carousel out
 
 - Badge and carousel colours (background, text, meta, dots) and spacing are managed via the settings page or shortcode attributes.
 - Target the `.sdc-review-carousel` wrapper or `.sdc-review-card` elements in your theme/custom CSS to tweak spacing, typography, or layout.
+- Use `.sdc-review-carousel__track` (or the existing `.sdc-review-carousel__list`) when you need to control the ticker transform—both host the flex layout for the sliding cards.
 - Dot navigation buttons use the `.sdc-review-carousel__dot` class; feel free to adjust size or colour to suit your brand.
 - The badge uses inline SVG icons, so colours inherit from the accent colour you set.
 

--- a/assets/css/review-carousel.css
+++ b/assets/css/review-carousel.css
@@ -14,24 +14,27 @@
 }
 
 .sdc-review-carousel__viewport {
+    position: relative;
     overflow: hidden;
 }
 
-.sdc-review-carousel__list {
+.sdc-review-carousel__list,
+.sdc-review-carousel__track {
     display: flex;
     gap: var(--sdc-review-gap);
     list-style: none;
     padding: 0;
     margin: 0;
-    overflow-x: auto;
-    scroll-snap-type: x mandatory;
-    scroll-padding: 1rem;
+    width: max-content;
+    min-width: 100%;
+}
+
+.sdc-review-carousel__list {
+    will-change: transform;
 }
 
 .sdc-review-carousel__item {
     flex: 0 0 calc((100% - (var(--sdc-review-current-slides) - 1) * var(--sdc-review-gap)) / var(--sdc-review-current-slides));
-    scroll-snap-align: start;
-    scroll-snap-stop: always;
 }
 
 .sdc-review-carousel__dots {


### PR DESCRIPTION
## Summary
- update the carousel list layout to remove scroll snap and prepare for a transform-driven ticker
- document the new ticker track styling hook in the README

## Testing
- not run (css-only change)

------
https://chatgpt.com/codex/tasks/task_b_68faf52a7bd4832c9c8f17f1ce8be32c